### PR TITLE
fix: `AttributeError` when getting next day's data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,3 @@ All notable changes to this project will be documented in this file. See [standa
 ### Features
 
 * adds OMIE sensors for marginal price and adjustment. support for en/es/pt languages. ([67b52f9](https://github.com/luuuis/hass_omie/commit/67b52f9dbc5f2015ac9c143d76f72b923a17b8ca))
-
-# Changelog
-
-All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.

--- a/custom_components/omie/__init__.py
+++ b/custom_components/omie/__init__.py
@@ -77,7 +77,7 @@ def async_update_omie(session: aiohttp.ClientSession) -> Callable[[], Awaitable[
 
 async def fetch_to_dict(session: aiohttp.ClientSession, source, fetch_date, short_names):
     async with await session.get(source, timeout=DEFAULT_TIMEOUT.total_seconds()) as resp:
-        if resp.status is 404:
+        if resp.status == 404:
             return None
 
         lines = (await resp.text(encoding='iso-8859-1')).splitlines()


### PR DESCRIPTION
Correctly handle 404 responses when fetching the next day's data before 12pm CET. Fixes #1.