### PR TITLE
fix: reduce number of network calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-yellow.svg?style=for-the-badge)](https://github.com/custom-components/hacs) [![GitHub release (latest by date)](https://img.shields.io/github/v/release/luuuis/hass_omie?label=Latest%20release&style=for-the-badge)](https://github.com/luuuis/hass_omie/releases) [![GitHub all releases](https://img.shields.io/github/downloads/luuuis/hass_omie/total?style=for-the-badge)](https://github.com/luuuis/hass_omie/releases)
 
-# Home Assistant OMIE Integration
+# OMIE Home Assistant Integration
 
 ## Features
 
@@ -60,7 +60,8 @@ Use [HACS](https://hacs.xyz) (preferred) or follow the manual instructions below
 
 # Configuration
 
-Go to the `Integrations` page, click `Add Integration` and select the OMIE integration or click the following button.
+Go to the `Integrations` page, click `Add Integration` and select the OMIE Home Assistant Integration or click the
+following button.
 
 [![Open your Home Assistant instance and start setting up a new integration.](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=omie)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ General notes regarding the sensors:
 * Daily average and hourly values are available in each sensor's attributes.
 * Unwanted sensors may be disabled in each sensor's Settings after installation.
 * Sensors marked with a (P) contain **Provisional** values until the results of the last intraday market session are
-  published.
+  published at around 10:30 PM on the day.
 
 ## Installation
 

--- a/custom_components/omie/__init__.py
+++ b/custom_components/omie/__init__.py
@@ -1,29 +1,36 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, date, timedelta
-from typing import Any, Awaitable, NamedTuple, Callable
+from datetime import date, timedelta
 
-import aiohttp
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (DOMAIN, DEFAULT_UPDATE_INTERVAL, DEFAULT_TIMEOUT)
-from .coordinator import spot_price, adjustment_price
+from .coordinator import spot_price, adjustment_price, OMIEDailyCoordinator
+from .model import OMIECoordinators
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up from a config entry."""
-    hass.data[DOMAIN] = DataUpdateCoordinator[OMIEData](
-        hass,
-        _LOGGER,
-        name=DOMAIN,
-        update_method=async_update_omie(async_get_clientsession(hass)),
-        update_interval=DEFAULT_UPDATE_INTERVAL,
+    session = async_get_clientsession(hass)
+
+    today = date.today
+    tomorrow = lambda: today() + timedelta(days=1)
+
+    hass.data[DOMAIN] = OMIECoordinators(
+        spot=OMIEDailyCoordinator(hass, "spot", update_method=spot_price(session, today)),
+        spot_next=OMIEDailyCoordinator(hass, "spot_next", update_method=spot_price(session, tomorrow), none_before="13:30"),
+
+        adjustment=OMIEDailyCoordinator(hass, "adjustment",
+                                        update_method=adjustment_price(session, today), update_interval=timedelta(hours=1)),
+
+        adjustment_next=OMIEDailyCoordinator(hass, "adjustment_next",
+                                             update_method=adjustment_price(session, tomorrow), update_interval=timedelta(hours=1),
+                                             none_before="13:30"),
     )
 
     hass.async_create_task(hass.config_entries.async_forward_entry_setup(entry, "sensor"))
@@ -35,40 +42,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.pop(DOMAIN)
     hass.async_create_task(hass.config_entries.async_forward_entry_unload(entry, "sensor"))
     return True
-
-
-class OMIEPrices(NamedTuple):
-    spot: dict[str, Any] | None
-    adjustment: dict[str, Any] | None
-
-
-class OMIEData(NamedTuple):
-    today: OMIEPrices
-    tomorrow: OMIEPrices
-
-
-def async_update_omie(session: aiohttp.ClientSession) -> Callable[[], Awaitable[OMIEData]]:
-    # cached value to avoid unnecessary network calls
-    last_value: tuple[datetime, OMIEData] | None = None
-
-    async def fetch_prices(fetch_date: date) -> OMIEPrices:
-        return OMIEPrices(
-            spot=await spot_price(session, fetch_date),
-            adjustment=await adjustment_price(session, fetch_date)
-        )
-
-    async def do_update() -> OMIEData:
-        nonlocal last_value
-        # if last_value is not None:
-        #     pass
-
-        now_date = date.today()
-        omie_data = OMIEData(
-            today=await fetch_prices(now_date),
-            tomorrow=await fetch_prices(now_date + timedelta(days=1)),
-        )
-
-        last_value = (datetime.now(), omie_data)
-        return omie_data
-
-    return do_update

--- a/custom_components/omie/__init__.py
+++ b/custom_components/omie/__init__.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
-import csv
 import logging
-import statistics
 from datetime import datetime, date, timedelta
 from typing import Any, Awaitable, NamedTuple, Callable
 
 import aiohttp
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
 from .const import (DOMAIN, DEFAULT_UPDATE_INTERVAL, DEFAULT_TIMEOUT)
+from .coordinator import spot_price, adjustment_price
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -73,78 +72,3 @@ def async_update_omie(session: aiohttp.ClientSession) -> Callable[[], Awaitable[
         return omie_data
 
     return do_update
-
-
-async def fetch_to_dict(session: aiohttp.ClientSession, source, fetch_date, short_names):
-    async with await session.get(source, timeout=DEFAULT_TIMEOUT.total_seconds()) as resp:
-        if resp.status == 404:
-            return None
-
-        lines = (await resp.text(encoding='iso-8859-1')).splitlines()
-        header = lines[0]
-        data = lines[2:]
-
-        reader = csv.reader(data, delimiter=';', skipinitialspace=True)
-        rows = {row[0]: [float(row[i + 1].replace(',', '.')) for i in list(range(24))] for row in reader if row[0] != ''}
-
-        file_data = {
-            'header': header,
-            'fetched': datetime.now().isoformat(),
-            'market_date': fetch_date.isoformat(),
-            'source': source,
-        }
-
-        for k in rows:
-            hourly = rows[k]
-            if k in short_names:
-                # hourly & daily avg/sum
-                key = short_names[k]
-
-                suffix, daily = ['average', round(statistics.mean(hourly), 2)] if "(EUR/MWh)" in k else ['total', round(sum(hourly), 1)]
-                file_data.update({
-                    f'{key}_day_{suffix}': daily,
-                    f'{key}_hourly': hourly,
-                })
-            else:
-                # unknown rows, do not process
-                file_data.update({k: hourly})
-
-        return file_data
-
-
-def explode(fetch_date: datetime.date):
-    yy = fetch_date.year
-    MM = str.zfill(str(fetch_date.month), 2)
-    dd = str.zfill(str(fetch_date.day), 2)
-    return yy, MM, dd, f'{dd}_{MM}_{yy}'
-
-
-async def spot_price(client_session, fetch_date) -> dict[str, float]:
-    yy, MM, dd, dd_MM_yy = explode(fetch_date)
-    source = f'https://www.omie.es/sites/default/files/dados/AGNO_{yy}/MES_{MM}/TXT/INT_PBC_EV_H_1_{dd_MM_yy}_{dd_MM_yy}.TXT'
-
-    return await fetch_to_dict(client_session, source, fetch_date, {
-        "Energía total con bilaterales del mercado Ibérico (MWh)": 'energy_with_bilaterals_es_pt',
-        "Energía total de compra sistema español (MWh)": 'energy_purchases_es',
-        "Energía total de compra sistema portugués (MWh)": 'energy_purchases_pt',
-        "Energía total de venta sistema español (MWh)": 'energy_sales_es',
-        "Energía total de venta sistema portugués (MWh)": 'energy_sales_pt',
-        "Energía total del mercado Ibérico (MWh)": 'energy_es_pt',
-        "Exportación de España a Portugal (MWh)": 'energy_export_es_to_pt',
-        "Importación de España desde Portugal (MWh)": 'energy_import_es_from_pt',
-        "Precio marginal en el sistema español (EUR/MWh)": 'spot_price_es',
-        "Precio marginal en el sistema portugués (EUR/MWh)": 'spot_price_pt',
-    })
-
-
-async def adjustment_price(client_session, fetch_date) -> dict[str, float]:
-    yy, MM, dd, dd_MM_yy = explode(fetch_date)
-    source = f'https://www.omie.es/sites/default/files/dados/AGNO_{yy}/MES_{MM}/TXT/INT_MAJ_EV_H_{dd_MM_yy}_{dd_MM_yy}.TXT'
-
-    return await fetch_to_dict(client_session, source, fetch_date, {
-        "Precio de ajuste en el sistema español (EUR/MWh)": 'adjustment_price_es',
-        "Precio de ajuste en el sistema portugués (EUR/MWh)": 'adjustment_price_pt',
-        "Energía horaria sujeta al MAJ a los consumidores MIBEL (MWh)": 'adjustment_energy',
-        "Energía horaria sujeta al mecanismo de ajuste a los consumidores MIBEL (MWh)": 'adjustment_energy',
-        "Cuantía unitaria del ajuste (EUR/MWh)": 'adjustment_unit_price',
-    })

--- a/custom_components/omie/coordinator.py
+++ b/custom_components/omie/coordinator.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import csv
+import logging
+import statistics
+from datetime import datetime
+
+import aiohttp
+
+from .const import DEFAULT_TIMEOUT
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def fetch_to_dict(session: aiohttp.ClientSession, source, fetch_date, short_names):
+    async with await session.get(source, timeout=DEFAULT_TIMEOUT.total_seconds()) as resp:
+        if resp.status == 404:
+            return None
+
+        lines = (await resp.text(encoding='iso-8859-1')).splitlines()
+        header = lines[0]
+        data = lines[2:]
+
+        reader = csv.reader(data, delimiter=';', skipinitialspace=True)
+        rows = {row[0]: [float(row[i + 1].replace(',', '.')) for i in list(range(24))] for row in reader if row[0] != ''}
+
+        file_data = {
+            'header': header,
+            'fetched': datetime.now().isoformat(),
+            'market_date': fetch_date.isoformat(),
+            'source': source,
+        }
+
+        for k in rows:
+            hourly = rows[k]
+            if k in short_names:
+                # hourly & daily avg/sum
+                key = short_names[k]
+
+                suffix, daily = ['average', round(statistics.mean(hourly), 2)] if "(EUR/MWh)" in k else ['total', round(sum(hourly), 1)]
+                file_data.update({
+                    f'{key}_day_{suffix}': daily,
+                    f'{key}_hourly': hourly,
+                })
+            else:
+                # unknown rows, do not process
+                file_data.update({k: hourly})
+
+        return file_data
+
+
+def _explode(fetch_date: datetime.date):
+    yy = fetch_date.year
+    MM = str.zfill(str(fetch_date.month), 2)
+    dd = str.zfill(str(fetch_date.day), 2)
+    return yy, MM, dd, f'{dd}_{MM}_{yy}'
+
+
+async def spot_price(client_session, fetch_date) -> dict[str, float]:
+    yy, MM, dd, dd_MM_yy = _explode(fetch_date)
+    source = f'https://www.omie.es/sites/default/files/dados/AGNO_{yy}/MES_{MM}/TXT/INT_PBC_EV_H_1_{dd_MM_yy}_{dd_MM_yy}.TXT'
+
+    return await fetch_to_dict(client_session, source, fetch_date, {
+        "Energía total con bilaterales del mercado Ibérico (MWh)": 'energy_with_bilaterals_es_pt',
+        "Energía total de compra sistema español (MWh)": 'energy_purchases_es',
+        "Energía total de compra sistema portugués (MWh)": 'energy_purchases_pt',
+        "Energía total de venta sistema español (MWh)": 'energy_sales_es',
+        "Energía total de venta sistema portugués (MWh)": 'energy_sales_pt',
+        "Energía total del mercado Ibérico (MWh)": 'energy_es_pt',
+        "Exportación de España a Portugal (MWh)": 'energy_export_es_to_pt',
+        "Importación de España desde Portugal (MWh)": 'energy_import_es_from_pt',
+        "Precio marginal en el sistema español (EUR/MWh)": 'spot_price_es',
+        "Precio marginal en el sistema portugués (EUR/MWh)": 'spot_price_pt',
+    })
+
+
+async def adjustment_price(client_session, fetch_date) -> dict[str, float]:
+    yy, MM, dd, dd_MM_yy = _explode(fetch_date)
+    source = f'https://www.omie.es/sites/default/files/dados/AGNO_{yy}/MES_{MM}/TXT/INT_MAJ_EV_H_{dd_MM_yy}_{dd_MM_yy}.TXT'
+
+    return await fetch_to_dict(client_session, source, fetch_date, {
+        "Precio de ajuste en el sistema español (EUR/MWh)": 'adjustment_price_es',
+        "Precio de ajuste en el sistema portugués (EUR/MWh)": 'adjustment_price_pt',
+        "Energía horaria sujeta al MAJ a los consumidores MIBEL (MWh)": 'adjustment_energy',
+        "Energía horaria sujeta al mecanismo de ajuste a los consumidores MIBEL (MWh)": 'adjustment_energy',
+        "Cuantía unitaria del ajuste (EUR/MWh)": 'adjustment_unit_price',
+    })

--- a/custom_components/omie/coordinator.py
+++ b/custom_components/omie/coordinator.py
@@ -2,17 +2,106 @@ from __future__ import annotations
 
 import csv
 import logging
+import random
 import statistics
-from datetime import datetime
+from datetime import timedelta, datetime, date
+from typing import Callable, Awaitable, Optional
 
 import aiohttp
+import pytz
+from aiohttp import ClientSession
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import event
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util import utcnow
 
-from .const import DEFAULT_TIMEOUT
+from .const import DOMAIN, DEFAULT_TIMEOUT
+from .model import OMIEFile, OMIEModel
 
 _LOGGER = logging.getLogger(__name__)
+_CET = pytz.timezone("CET")
 
 
-async def fetch_to_dict(session: aiohttp.ClientSession, source, fetch_date, short_names):
+# language=Markdown
+#
+# OMIE market sessions and the values that they influence. Time shown below is publication time in the CET timezone plus 10 minutes.
+#
+# ```
+# | Time  | Name        | Spot | Adj  | Spot+1 | Ajd+1 |
+# |-------|-------------|------|------|--------|-------|
+# | 02:30 | Intraday 4  |  X   |  X   |        |       |
+# | 05:30 | Intraday 5  |  X   |  X   |        |       |
+# | 10:30 | Intraday 6  |  X   |  X   |        |       |
+# | 13:30 | Day-ahead   |      |      |   X    |   X   |
+# | 16:30 | Intraday 1  |      |      |   X    |   X   |
+# | 18:30 | Intraday 2  |  X   |  X   |   X    |   X   |
+# | 22:30 | Intraday 3  |      |      |   X    |   X   |
+# ```
+#
+# References:
+# - https://www.omie.es/en/mercado-de-electricidad
+# - https://www.omie.es/sites/default/files/inline-files/intraday_and_continuous_markets.pdf
+
+
+class OMIEDailyCoordinator(DataUpdateCoordinator[OMIEModel]):
+    """Coordinator that fetches new data once per day at the specified time, optionally refreshing it throughout the day."""
+
+    def __init__(self,
+                 hass: HomeAssistant,
+                 name: str,
+                 none_before: str = "00:00",
+                 update_interval: timedelta | None = None,
+                 update_method: Callable[[], Awaitable[OMIEModel]] | None = None) -> None:
+        super().__init__(hass, _LOGGER, name=f'{DOMAIN}.{name}', update_interval=update_interval, update_method=update_method)
+        hour, minute = none_before.split(":")
+        self._cet_hour = int(hour)
+        self._cet_minute = int(minute)
+        self._second = random.randint(0, 3)
+
+    async def _async_update_data(self) -> OMIEModel | None:
+        now = utcnow().astimezone()
+        none_before = now.astimezone(_CET).replace(hour=self._cet_hour, minute=self._cet_minute, second=0, microsecond=self._microsecond)
+
+        # @todo review edge cases around WET/CET disparity (e.g. when none_before is previous day in PT)
+        if now < none_before:
+            # no results can possibly be available at this time of day
+            _LOGGER.debug("%s: _async_update_data returning None before %s:%s CET", self.name, self._cet_hour, self._cet_minute)
+            return None
+
+        if self.data and (self.update_interval is None or now < (self.data.updated_at + self.update_interval)):
+            # current results are still fresh, don't update:
+            _LOGGER.debug("%s: _async_update_data returning cached (updated_at=%s, update_interval=%s)", self.name, self.data.updated_at,
+                          self.update_interval)
+            return self.data
+
+        else:
+            _LOGGER.debug("%s: _async_update_data refreshing data", self.name)
+            return await super()._async_update_data()
+
+    @callback
+    def _schedule_refresh(self) -> None:
+        """Schedule a refresh."""
+        if self.config_entry and self.config_entry.pref_disable_polling:
+            return
+
+        if self._unsub_refresh:
+            self._unsub_refresh()
+            self._unsub_refresh = None
+
+        now_cet = utcnow().astimezone(_CET)
+        none_before = now_cet.replace(hour=self._cet_hour, minute=self._cet_minute, second=self._second, microsecond=self._microsecond)
+        next_hour = now_cet.replace(minute=0, second=self._second, microsecond=self._microsecond) + timedelta(hours=1)
+
+        # next hour or the none_before time, whichever is soonest
+        next_refresh = (none_before if self._cet_hour == now_cet.hour and none_before > now_cet else next_hour).astimezone()
+
+        _LOGGER.debug("%s: _schedule_refresh scheduling an update at %s (none_before=%s, next_hour=%s)", self.name,
+                      next_refresh,
+                      none_before, next_hour)
+        self._unsub_refresh = event.async_track_point_in_utc_time(self.hass, self._job, next_refresh)
+
+
+async def fetch_to_dict(session: aiohttp.ClientSession, source, fetch_date, short_names) -> Optional[OMIEModel]:
     async with await session.get(source, timeout=DEFAULT_TIMEOUT.total_seconds()) as resp:
         if resp.status == 404:
             return None
@@ -26,7 +115,7 @@ async def fetch_to_dict(session: aiohttp.ClientSession, source, fetch_date, shor
 
         file_data = {
             'header': header,
-            'fetched': datetime.now().isoformat(),
+            'fetched': utcnow().isoformat(),
             'market_date': fetch_date.isoformat(),
             'source': source,
         }
@@ -46,7 +135,10 @@ async def fetch_to_dict(session: aiohttp.ClientSession, source, fetch_date, shor
                 # unknown rows, do not process
                 file_data.update({k: hourly})
 
-        return file_data
+        return OMIEModel(
+            updated_at=utcnow(),
+            contents=file_data
+        )
 
 
 def _explode(fetch_date: datetime.date):
@@ -56,32 +148,40 @@ def _explode(fetch_date: datetime.date):
     return yy, MM, dd, f'{dd}_{MM}_{yy}'
 
 
-async def spot_price(client_session, fetch_date) -> dict[str, float]:
-    yy, MM, dd, dd_MM_yy = _explode(fetch_date)
-    source = f'https://www.omie.es/sites/default/files/dados/AGNO_{yy}/MES_{MM}/TXT/INT_PBC_EV_H_1_{dd_MM_yy}_{dd_MM_yy}.TXT'
+def spot_price(client_session: ClientSession, get_date: Callable[[], date]) -> Callable[[], Awaitable[OMIEModel]]:
+    async def fetch() -> OMIEModel:
+        fetch_date = get_date()
+        yy, MM, dd, dd_MM_yy = _explode(fetch_date)
+        source = f'https://www.omie.es/sites/default/files/dados/AGNO_{yy}/MES_{MM}/TXT/INT_PBC_EV_H_1_{dd_MM_yy}_{dd_MM_yy}.TXT'
 
-    return await fetch_to_dict(client_session, source, fetch_date, {
-        "Energía total con bilaterales del mercado Ibérico (MWh)": 'energy_with_bilaterals_es_pt',
-        "Energía total de compra sistema español (MWh)": 'energy_purchases_es',
-        "Energía total de compra sistema portugués (MWh)": 'energy_purchases_pt',
-        "Energía total de venta sistema español (MWh)": 'energy_sales_es',
-        "Energía total de venta sistema portugués (MWh)": 'energy_sales_pt',
-        "Energía total del mercado Ibérico (MWh)": 'energy_es_pt',
-        "Exportación de España a Portugal (MWh)": 'energy_export_es_to_pt',
-        "Importación de España desde Portugal (MWh)": 'energy_import_es_from_pt',
-        "Precio marginal en el sistema español (EUR/MWh)": 'spot_price_es',
-        "Precio marginal en el sistema portugués (EUR/MWh)": 'spot_price_pt',
-    })
+        return await fetch_to_dict(client_session, source, fetch_date, {
+            "Energía total con bilaterales del mercado Ibérico (MWh)": 'energy_with_bilaterals_es_pt',
+            "Energía total de compra sistema español (MWh)": 'energy_purchases_es',
+            "Energía total de compra sistema portugués (MWh)": 'energy_purchases_pt',
+            "Energía total de venta sistema español (MWh)": 'energy_sales_es',
+            "Energía total de venta sistema portugués (MWh)": 'energy_sales_pt',
+            "Energía total del mercado Ibérico (MWh)": 'energy_es_pt',
+            "Exportación de España a Portugal (MWh)": 'energy_export_es_to_pt',
+            "Importación de España desde Portugal (MWh)": 'energy_import_es_from_pt',
+            "Precio marginal en el sistema español (EUR/MWh)": 'spot_price_es',
+            "Precio marginal en el sistema portugués (EUR/MWh)": 'spot_price_pt',
+        })
+
+    return fetch
 
 
-async def adjustment_price(client_session, fetch_date) -> dict[str, float]:
-    yy, MM, dd, dd_MM_yy = _explode(fetch_date)
-    source = f'https://www.omie.es/sites/default/files/dados/AGNO_{yy}/MES_{MM}/TXT/INT_MAJ_EV_H_{dd_MM_yy}_{dd_MM_yy}.TXT'
+def adjustment_price(client_session: ClientSession, get_date: Callable[[], date]) -> Callable[[], Awaitable[OMIEFile]]:
+    async def fetch():
+        fetch_date = get_date()
+        yy, MM, dd, dd_MM_yy = _explode(fetch_date)
+        source = f'https://www.omie.es/sites/default/files/dados/AGNO_{yy}/MES_{MM}/TXT/INT_MAJ_EV_H_{dd_MM_yy}_{dd_MM_yy}.TXT'
 
-    return await fetch_to_dict(client_session, source, fetch_date, {
-        "Precio de ajuste en el sistema español (EUR/MWh)": 'adjustment_price_es',
-        "Precio de ajuste en el sistema portugués (EUR/MWh)": 'adjustment_price_pt',
-        "Energía horaria sujeta al MAJ a los consumidores MIBEL (MWh)": 'adjustment_energy',
-        "Energía horaria sujeta al mecanismo de ajuste a los consumidores MIBEL (MWh)": 'adjustment_energy',
-        "Cuantía unitaria del ajuste (EUR/MWh)": 'adjustment_unit_price',
-    })
+        return await fetch_to_dict(client_session, source, fetch_date, {
+            "Precio de ajuste en el sistema español (EUR/MWh)": 'adjustment_price_es',
+            "Precio de ajuste en el sistema portugués (EUR/MWh)": 'adjustment_price_pt',
+            "Energía horaria sujeta al MAJ a los consumidores MIBEL (MWh)": 'adjustment_energy',
+            "Energía horaria sujeta al mecanismo de ajuste a los consumidores MIBEL (MWh)": 'adjustment_energy',
+            "Cuantía unitaria del ajuste (EUR/MWh)": 'adjustment_unit_price',
+        })
+
+    return fetch

--- a/custom_components/omie/model.py
+++ b/custom_components/omie/model.py
@@ -11,6 +11,7 @@ _LOGGER = logging.getLogger(__name__)
 OMIEFile = dict[str, Union[float, list[float]]]
 """A dict parsed from one of the OMIE CSV file."""
 
+
 class OMIEModel(NamedTuple):
     """A piece of data updated at a particular time."""
     updated_at: datetime

--- a/custom_components/omie/model.py
+++ b/custom_components/omie/model.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import NamedTuple, Union
+
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+OMIEFile = dict[str, Union[float, list[float]]]
+"""A dict parsed from one of the OMIE CSV file."""
+
+
+# class OMIEFile(NamedTuple):
+#     data: OMIEDict
+
+class OMIEModel(NamedTuple):
+    """A piece of data updated at a particular time."""
+    updated_at: datetime
+    contents: OMIEFile
+
+
+class OMIECoordinators(NamedTuple):
+    spot: DataUpdateCoordinator[OMIEModel]
+    """Today's spot."""
+
+    spot_next: DataUpdateCoordinator[OMIEModel]
+    """Tomorrow's spot."""
+
+    adjustment: DataUpdateCoordinator[OMIEModel]
+    """Today's adjustment."""
+
+    adjustment_next: DataUpdateCoordinator[OMIEModel]
+    """Tomorrow's adjustment."""

--- a/custom_components/omie/model.py
+++ b/custom_components/omie/model.py
@@ -11,10 +11,6 @@ _LOGGER = logging.getLogger(__name__)
 OMIEFile = dict[str, Union[float, list[float]]]
 """A dict parsed from one of the OMIE CSV file."""
 
-
-# class OMIEFile(NamedTuple):
-#     data: OMIEDict
-
 class OMIEModel(NamedTuple):
     """A piece of data updated at a particular time."""
     updated_at: datetime

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 homeassistant==2023.2.0
+aiohttp~=3.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 homeassistant==2023.2.0
 aiohttp~=3.8.1
+pytz~=2022.7.1


### PR DESCRIPTION
Use several coordinators that update the sensors on an hourly basis but only refresh data when necessary:
1. When a new day rolls over
2. When a new file becomes available (e.g. after day-ahead market publication)
3. When the data may be stale as per `update_interval`

This avoids hammering OMIE servers more than necessary.

<img src="https://user-images.githubusercontent.com/161006/221422164-18f7489f-f442-4c2f-8518-d4d91030a671.jpg" width="400"></img>
