### PR TITLE
fix: spot/adjustment sensors not refreshing when a new day rolls over

### DIFF
--- a/custom_components/omie/__init__.py
+++ b/custom_components/omie/__init__.py
@@ -5,7 +5,6 @@ from datetime import date, timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (DOMAIN, DEFAULT_UPDATE_INTERVAL, DEFAULT_TIMEOUT)
 from .coordinator import spot_price, adjustment_price, OMIEDailyCoordinator
@@ -16,20 +15,32 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up from a config entry."""
-    session = async_get_clientsession(hass)
-
     today = date.today
     tomorrow = lambda: today() + timedelta(days=1)
 
     hass.data[DOMAIN] = OMIECoordinators(
-        spot=OMIEDailyCoordinator(hass, "spot", update_method=spot_price(session, today)),
-        spot_next=OMIEDailyCoordinator(hass, "spot_next", update_method=spot_price(session, tomorrow), none_before="13:30"),
+        spot=OMIEDailyCoordinator(hass,
+                                  "spot",
+                                  market_updater=spot_price,
+                                  market_date=today),
 
-        adjustment=OMIEDailyCoordinator(hass, "adjustment",
-                                        update_method=adjustment_price(session, today), update_interval=timedelta(hours=1)),
+        spot_next=OMIEDailyCoordinator(hass,
+                                       "spot_next",
+                                       market_updater=spot_price,
+                                       market_date=tomorrow,
+                                       none_before="13:30"),
 
-        adjustment_next=OMIEDailyCoordinator(hass, "adjustment_next",
-                                             update_method=adjustment_price(session, tomorrow), update_interval=timedelta(hours=1),
+        adjustment=OMIEDailyCoordinator(hass,
+                                        "adjustment",
+                                        market_updater=adjustment_price,
+                                        market_date=today,
+                                        update_interval=timedelta(hours=1)),
+
+        adjustment_next=OMIEDailyCoordinator(hass,
+                                             "adjustment_next",
+                                             market_updater=adjustment_price,
+                                             market_date=tomorrow,
+                                             update_interval=timedelta(hours=1),
                                              none_before="13:30"),
     )
 

--- a/custom_components/omie/model.py
+++ b/custom_components/omie/model.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, date
 from typing import NamedTuple, Union
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -15,6 +15,9 @@ OMIEFile = dict[str, Union[float, list[float]]]
 class OMIEModel(NamedTuple):
     """A piece of data updated at a particular time."""
     updated_at: datetime
+    """The fetch date/time."""
+    market_date: date
+    """The day that the data relates to."""
     contents: OMIEFile
 
 


### PR DESCRIPTION
Values were being cached indefinitely for coordinators that did not specify an `update_interval`.