### PR TITLE
fix: clear _tomorrow sensor attributes when state is unknown

### DIFF
--- a/custom_components/omie/sensor.py
+++ b/custom_components/omie/sensor.py
@@ -107,6 +107,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                         }
                     else:
                         self._attr_native_value = None
+                        self._attr_extra_state_attributes = None
 
                     self.async_schedule_update_ha_state()
 


### PR DESCRIPTION
Fixes a bug whereby the sensor attributes would retain old values from the previous day until refreshed at 12:30.