### PR TITLE
feat!: changed sensors and correctly handle non-CET local time zones

### DIFF
--- a/custom_components/omie/__init__.py
+++ b/custom_components/omie/__init__.py
@@ -1,47 +1,69 @@
 from __future__ import annotations
 
 import logging
-from datetime import date, timedelta
+from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.util import utcnow
 
-from .const import (DOMAIN, DEFAULT_UPDATE_INTERVAL, DEFAULT_TIMEOUT)
+from .const import (DOMAIN, DEFAULT_UPDATE_INTERVAL, DEFAULT_TIMEOUT, CET)
 from .coordinator import spot_price, adjustment_price, OMIEDailyCoordinator
-from .model import OMIECoordinators
+from .model import OMIECoordinators, OMIESources
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up from a config entry."""
-    today = date.today
-    tomorrow = lambda: today() + timedelta(days=1)
+
+    # OMIE data is in the CET timezone so today's date locally may be tomorrow
+    # or yesterday in that timezone. we fetch (today-1,today,today+1) as that is
+    # needed to correctly handle the hours when PT and ES are on different dates.
+    cet_today = lambda: utcnow().astimezone(CET).date()
+    cet_tomorrow = lambda: cet_today() + timedelta(days=1)
+    cet_yesterday = lambda: cet_today() - timedelta(days=1)
+
+    # These are asking to be rewritten into coordinators that do 3 fetches for each
+    # OMIE source file (one for spot and one for adjustment).
+
+    spot = OMIEDailyCoordinator(hass,
+                                "spot",
+                                market_updater=spot_price,
+                                market_date=cet_today)
+
+    spot_next = OMIEDailyCoordinator(hass,
+                                     "spot_next",
+                                     market_updater=spot_price,
+                                     market_date=cet_tomorrow,
+                                     none_before="13:30")
+
+    spot_previous = OMIEDailyCoordinator(hass,
+                                         "spot_previous",
+                                         market_updater=spot_price,
+                                         market_date=cet_yesterday)
+
+    adjustment = OMIEDailyCoordinator(hass,
+                                      "adjustment",
+                                      market_updater=adjustment_price,
+                                      market_date=cet_today,
+                                      update_interval=timedelta(hours=1))
+
+    adjustment_next = OMIEDailyCoordinator(hass,
+                                           "adjustment_next",
+                                           market_updater=adjustment_price,
+                                           market_date=cet_tomorrow,
+                                           update_interval=timedelta(hours=1),
+                                           none_before="13:30")
+
+    adjustment_previous = OMIEDailyCoordinator(hass,
+                                               "adjustment_previous",
+                                               market_updater=adjustment_price,
+                                               market_date=cet_yesterday)
 
     hass.data[DOMAIN] = OMIECoordinators(
-        spot=OMIEDailyCoordinator(hass,
-                                  "spot",
-                                  market_updater=spot_price,
-                                  market_date=today),
-
-        spot_next=OMIEDailyCoordinator(hass,
-                                       "spot_next",
-                                       market_updater=spot_price,
-                                       market_date=tomorrow,
-                                       none_before="13:30"),
-
-        adjustment=OMIEDailyCoordinator(hass,
-                                        "adjustment",
-                                        market_updater=adjustment_price,
-                                        market_date=today,
-                                        update_interval=timedelta(hours=1)),
-
-        adjustment_next=OMIEDailyCoordinator(hass,
-                                             "adjustment_next",
-                                             market_updater=adjustment_price,
-                                             market_date=tomorrow,
-                                             update_interval=timedelta(hours=1),
-                                             none_before="13:30"),
+        spot=OMIESources(today=spot, tomorrow=spot_next, yesterday=spot_previous),
+        adjustment=OMIESources(today=adjustment, tomorrow=adjustment_next, yesterday=adjustment_previous)
     )
 
     hass.async_create_task(hass.config_entries.async_forward_entry_setup(entry, "sensor"))

--- a/custom_components/omie/const.py
+++ b/custom_components/omie/const.py
@@ -2,7 +2,11 @@
 from datetime import timedelta
 from typing import Final
 
+import pytz
+
 DOMAIN: Final = "omie"
 DEFAULT_NAME: Final = "OMIE"
 DEFAULT_UPDATE_INTERVAL = timedelta(minutes=1)
 DEFAULT_TIMEOUT = timedelta(seconds=10)
+
+CET = pytz.timezone("CET")

--- a/custom_components/omie/model.py
+++ b/custom_components/omie/model.py
@@ -13,23 +13,32 @@ OMIEFile = dict[str, Union[float, list[float]]]
 
 
 class OMIEModel(NamedTuple):
-    """A piece of data updated at a particular time."""
+    """OMIE market results for a given date."""
     updated_at: datetime
     """The fetch date/time."""
+
     market_date: date
     """The day that the data relates to."""
+
     contents: OMIEFile
+    """Data fetched from OMIE."""
+
+
+class OMIESources(NamedTuple):
+    """Pair of coordinators that source OMIE market results for today and tomorrow."""
+    today: DataUpdateCoordinator[OMIEModel]
+    """Today's market results (CET)."""
+
+    tomorrow: DataUpdateCoordinator[OMIEModel]
+    """Tomorrow's market results (CET)."""
+
+    yesterday: DataUpdateCoordinator[OMIEModel]
+    """Yesterday's market results (CET)."""
 
 
 class OMIECoordinators(NamedTuple):
-    spot: DataUpdateCoordinator[OMIEModel]
-    """Today's spot."""
+    spot: OMIESources
+    """Spot prices."""
 
-    spot_next: DataUpdateCoordinator[OMIEModel]
-    """Tomorrow's spot."""
-
-    adjustment: DataUpdateCoordinator[OMIEModel]
-    """Today's adjustment."""
-
-    adjustment_next: DataUpdateCoordinator[OMIEModel]
-    """Tomorrow's adjustment."""
+    adjustment: OMIESources
+    """Adjustment mechanism prices."""


### PR DESCRIPTION
Preparing for v1, which will use different sensors and attributes. This is mainly driven by the need to handle non-CET local timezones correctly and to make the attribute data easier to work with.

* removed `_tomorrow` sensors in favour of attributes on the main sensor
* use local time zone when working out "today_" and "tomorrow_" attributes
* convert OMIE hours in CET time zone to HA's local time zone
* adds `_provisional` attribute for use when today_/tomorrow_ data is incomplete