### PR TITLE
fix: use constants for "€/MWh" and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,24 +7,18 @@
 Pulls data from [OMIE](https://omie.es) into Home Assistant. OMIE is the nominated electricity market operator (NEMO)
 for managing the Iberian Peninsula's day-ahead and intraday electricity markets.
 
-<img alt="OMIE sensors screenshot" src="https://user-images.githubusercontent.com/161006/220145634-06094b7b-2ef3-4a51-9ad1-718d8d8f9516.jpg" width="640"></img>
+<img alt="OMIE sensors screenshot" src="https://user-images.githubusercontent.com/161006/235292164-d552d1b2-0d2d-4931-a9ea-6954665cca23.jpg" width="640"></img>
 
 ### Sensors
 
 Provides the following sensors containing daily and day-ahead values.
 
-| Sensor                                   |  Unit   | Description                                                                                                                 |
-|------------------------------------------|:-------:|-----------------------------------------------------------------------------------------------------------------------------|
-| `omie_spot_price_es`                     | EUR/MWh | Marginal price for the current hour in Spain, determined in the day-ahead market of the previous day.                       |
-| `omie_spot_price_pt`                     | EUR/MWh | Marginal price for the current hour in Portugal, determined in the day-ahead market of the previous day.                    |
-| `omie_adjustment_price_es`(P)            | EUR/MWh | Adjustment mechanism price for the current hour paid by consumers in Spain.                                                 |
-| `omie_adjustment_price_pt`(P)            | EUR/MWh | Adjustment mechanism price for the current hour paid by consumers in Portugal.                                              |
-| `omie_adjustment_unit_price`(P)          | EUR/MWh | Adjustment unit amount for the current hour for production facilities entitled to receive the adjustment.                   |
-| `omie_spot_price_es_tomorrow`            | EUR/MWh | Marginal price for the current hour _of the next day_ in Spain, determined in the day-ahead market of the previous day.     |
-| `omie_spot_price_pt_tomorrow`            | EUR/MWh | Marginal price for the current hour _of the next day_ in Portugal, determined in the day-ahead market of the previous day.  |
-| `omie_adjustment_price_es_tomorrow`(P)   | EUR/MWh | Adjustment mechanism price for the current hour _of the next day_ paid by consumers in Spain.                               |
-| `omie_adjustment_price_pt_tomorrow`(P)   | EUR/MWh | Adjustment mechanism price for the current hour _of the next day_ paid by consumers in Portugal.                            |
-| `omie_adjustment_unit_price_tomorrow`(P) | EUR/MWh | Adjustment unit amount for the current hour _of the next day_ for production facilities entitled to receive the adjustment. |
+| Sensor                        | Unit  | Description                                                                                              |
+|-------------------------------|:-----:|----------------------------------------------------------------------------------------------------------|
+| `omie_spot_price_es`          | €/MWh | Marginal price for the current hour in Spain, determined in the day-ahead market of the previous day.    |
+| `omie_spot_price_pt`          | €/MWh | Marginal price for the current hour in Portugal, determined in the day-ahead market of the previous day. |
+| `omie_adjustment_price_es`(P) | €/MWh | Adjustment mechanism price for the current hour paid by consumers in Spain.                              |
+| `omie_adjustment_price_pt`(P) | €/MWh | Adjustment mechanism price for the current hour paid by consumers in Portugal.                           |
 
 General notes regarding the sensors:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Pulls data from [OMIE](https://omie.es) into Home Assistant. OMIE is the nominated electricity market operator (NEMO)
 for managing the Iberian Peninsula's day-ahead and intraday electricity markets.
 
-<img alt="OMIE sensors screenshot" src="https://user-images.githubusercontent.com/161006/235292164-d552d1b2-0d2d-4931-a9ea-6954665cca23.jpg" width="640"></img>
+<img alt="OMIE sensors screenshot" src="https://user-images.githubusercontent.com/161006/235292328-14b232dd-9d64-4030-a297-53e10a345cf1.jpg" width="640"></img>
 
 ### Sensors
 

--- a/custom_components/omie/sensor.py
+++ b/custom_components/omie/sensor.py
@@ -7,6 +7,8 @@ from datetime import datetime, timedelta, tzinfo, date
 import pytz
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.config_entries import (ConfigEntry)
+from homeassistant.const import CURRENCY_EURO
+from homeassistant.const import UnitOfEnergy
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
@@ -45,7 +47,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         def __init__(self, sources: OMIESources, key: str, tz: tzinfo):
             """Initialize the sensor."""
             self._attr_device_info = device_info
-            self._attr_native_unit_of_measurement = "EUR/MWh"
+            self._attr_native_unit_of_measurement = f"{CURRENCY_EURO}/{UnitOfEnergy.MEGA_WATT_HOUR}"
             self._attr_state_class = SensorStateClass.MEASUREMENT
             self._attr_unique_id = slugify(f'omie_{key}')
             self._attr_name = getattr(entity_names, f'{key}')


### PR DESCRIPTION
Updates the sensor to use the `CURRENCY_EURO` constant, which leads to a unit of measurement of `€/MWh` instead of `EUR/MWh`.

Also updates the README for the unit change as well as updates that I forgot to add in #14.

### Effect on long term statistics
Due to the unit change the Long Term Statistics will need to be updated as per the following screenshots.

![Developer Tools – Home Assistant 2023-04-29 09-02-19](https://user-images.githubusercontent.com/161006/235292431-852d8824-dae6-4043-b5b9-5d127ed253a9.jpg)
![Developer Tools – Home Assistant 2023-04-29 09-02-10](https://user-images.githubusercontent.com/161006/235292432-e7823c36-9aee-4669-adb4-9dfa52554ddc.jpg)
