### PR TITLE
fix(coordinator): convert DataUpdateCoordinator._microsecond to int

### DIFF
--- a/custom_components/omie/coordinator.py
+++ b/custom_components/omie/coordinator.py
@@ -93,8 +93,8 @@ class OMIEDailyCoordinator(DataUpdateCoordinator[OMIEModel]):
 
         cet_hour, cet_minute = self._none_before
         now_cet = utcnow().astimezone(CET)
-        none_before = now_cet.replace(hour=cet_hour, minute=cet_minute, second=self._second, microsecond=self._microsecond)
-        next_hour = now_cet.replace(minute=0, second=self._second, microsecond=self._microsecond) + timedelta(hours=1)
+        none_before = now_cet.replace(hour=cet_hour, minute=cet_minute, second=self._second, microsecond=int(self._microsecond * 10 ** 6))
+        next_hour = now_cet.replace(minute=0, second=self._second, microsecond=int(self._microsecond * 10 ** 6)) + timedelta(hours=1)
 
         # next hour or the none_before time, whichever is soonest
         next_refresh = (none_before if cet_hour == now_cet.hour and none_before > now_cet else next_hour).astimezone()
@@ -112,7 +112,7 @@ class OMIEDailyCoordinator(DataUpdateCoordinator[OMIEModel]):
             hour=cet_hour,
             minute=cet_minute,
             second=self._second,
-            microsecond=self._microsecond)
+            microsecond=int(self._microsecond * 10 ** 6))
 
         return cet_now < none_before and none_before.date() == cet_now.date()
 


### PR DESCRIPTION
HA's DataUpdateCoordinator stores the microsecond as a `float` for some reason. This has started failing in 2023.9 as the expected type if an `int`.

```
Logger: custom_components.omie.coordinator
Source: helpers/update_coordinator.py:293
Integration: OMIE - electricity market operator for the Iberian Peninsula ([documentation](https://github.com/luuuis/hass_omie), [issues](https://github.com/luuuis/hass_omie/issues))
First occurred: 12:12:57 (1 occurrences)
Last logged: 12:12:57

Unexpected error fetching omie.spot data: 'float' object cannot be interpreted as an integer
Traceback (most recent call last):
  File "/Users/luis/Workspace/home-assistant-core/homeassistant/helpers/update_coordinator.py", line 293, in _async_refresh
    self.data = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/luis/Workspace/hass_omie/custom_components/omie/coordinator.py", line 69, in _async_update_data
    if self._wait_for_none_before():
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/luis/Workspace/hass_omie/custom_components/omie/coordinator.py", line 111, in _wait_for_none_before
    none_before = cet_now.replace(
                  ^^^^^^^^^^^^^^^^
TypeError: 'float' object cannot be interpreted as an integer
```