### PR TITLE
fix: blocking pytz.timezone call from within event loop

### DIFF
--- a/custom_components/omie/sensor.py
+++ b/custom_components/omie/sensor.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, tzinfo, date
 import pytz
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.config_entries import (ConfigEntry)
-from homeassistant.const import CURRENCY_EURO
+from homeassistant.const import CURRENCY_EURO, EVENT_CORE_CONFIG_UPDATE
 from homeassistant.const import UnitOfEnergy
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceEntryType
@@ -16,7 +16,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import slugify, utcnow
 from pyomie.model import SpotData, OMIEResults
 from pyomie.util import localize_quarter_hourly_data
-from pytz.tzinfo import StaticTzInfo
 
 from . import OMIECoordinators
 from .const import DOMAIN, CET
@@ -59,10 +58,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             self._series = series
             self._sources = sources
             self._tz = tz
+            self._local_tz = None
             self.entity_id = f"sensor.{self._attr_unique_id}"
 
         async def async_added_to_hass(self) -> None:
             """Register callbacks."""
+            self._local_tz = await self.hass.async_add_executor_job(pytz.timezone, self.hass.config.time_zone)
 
             @callback
             def update() -> None:
@@ -82,14 +83,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                 cet_yesterday_hourly_data = _localize_quarter_hourly_data(yesterday_data, self._series)
                 cet_hourly_data = cet_yesterday_hourly_data | cet_today_hourly_data | cet_tomorrow_hourly_data
 
-                local_tz = pytz.timezone(self.hass.config.time_zone)
-                now = utcnow().astimezone(local_tz)
+                now = utcnow().astimezone(self._local_tz)
                 today = now.date()
                 tomorrow = today + timedelta(days=1)
 
-                local_today_hourly_data = {h: cet_hourly_data.get(h.astimezone(CET)) for h in _day_quarter_hours(today, local_tz)}
-                local_tomorrow_hourly_data = {h: cet_hourly_data.get(h.astimezone(CET)) for h in _day_quarter_hours(tomorrow, local_tz)}
-                local_start_of_quarter_hour = local_tz.normalize(now.replace(minute=now.minute // 15 * 15, second=0, microsecond=0))
+                local_today_hourly_data = {h: cet_hourly_data.get(h.astimezone(CET)) for h in _day_quarter_hours(today, self._local_tz)}
+                local_tomorrow_hourly_data = {h: cet_hourly_data.get(h.astimezone(CET)) for h in _day_quarter_hours(tomorrow, self._local_tz)}
+                local_start_of_quarter_hour = self._local_tz.normalize(now.replace(minute=now.minute // 15 * 15, second=0, microsecond=0))
 
                 self._attr_native_value = local_today_hourly_data.get(local_start_of_quarter_hour)
                 self._attr_extra_state_attributes = {
@@ -105,6 +105,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
                 self.async_schedule_update_ha_state()
 
+            async def handle_core_config_update(event) -> None:
+                if 'time_zone' in event.data:
+                    self._local_tz = await self.hass.async_add_executor_job(pytz.timezone, self.hass.config.time_zone)
+                    update()
+
+            self.async_on_remove(self.hass.bus.async_listen(EVENT_CORE_CONFIG_UPDATE, handle_core_config_update))
             self.async_on_remove(self._sources.today.async_add_listener(update))
             self.async_on_remove(self._sources.tomorrow.async_add_listener(update))
             self.async_on_remove(self._sources.yesterday.async_add_listener(update))
@@ -137,7 +143,7 @@ def _localize_quarter_hourly_data(results: OMIEResults[SpotData], series_name: s
     }
 
 
-def _day_quarter_hours(day: date, tz: StaticTzInfo) -> list[datetime]:
+def _day_quarter_hours(day: date, tz) -> list[datetime]:
     """Returns a list of every hour in the given date, normalized to the given time zone."""
     zero = tz.localize(datetime(day.year, day.month, day.day))
     quarter = [tz.normalize(zero + timedelta(hours=m // 4, minutes=(m % 4) * 15)) for m in range(25 * 4)]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: 'latest'
 services:
   home-assistant:
     container_name: homeassistant_omie
-    image: ghcr.io/home-assistant/home-assistant:2025.1.1
+    image: ghcr.io/home-assistant/home-assistant:2026.5.4
     environment:
       - TZ=UTC
     ports:


### PR DESCRIPTION
This is now called from `async_added_to_hass` at start up and then again if the configured TZ changes.

```
homeassistant_omie  | 2026-05-24 16:12:54.688 WARNING (MainThread) [homeassistant.util.loop] Detected blocking call to open with args ('/usr/local/lib/python3.14/site-packages/pytz/zoneinfo/Africa/Maputo', 'rb') inside the event loop by custom integration 'omie' at custom_components/omie/sensor.py, line 85: local_tz = pytz.timezone(self.hass.config.time_zone) (offender: /usr/local/lib/python3.14/site-packages/pytz/__init__.py, line 118: return open(filename, 'rb')), please create a bug report at https://github.com/luuuis/hass_omie/issues
homeassistant_omie  | For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#open
homeassistant_omie  | Traceback (most recent call last):
homeassistant_omie  |   File "<frozen runpy>", line 198, in _run_module_as_main
homeassistant_omie  |   File "<frozen runpy>", line 88, in _run_code
homeassistant_omie  |   File "/usr/src/homeassistant/homeassistant/__main__.py", line 229, in <module>
homeassistant_omie  |     sys.exit(main())
homeassistant_omie  |   File "/usr/src/homeassistant/homeassistant/__main__.py", line 215, in main
homeassistant_omie  |     exit_code = runner.run(runtime_conf)
homeassistant_omie  |   File "/usr/src/homeassistant/homeassistant/runner.py", line 289, in run
homeassistant_omie  |     return loop.run_until_complete(setup_and_run_hass(runtime_config))
homeassistant_omie  |   File "/usr/local/lib/python3.14/asyncio/base_events.py", line 706, in run_until_complete
homeassistant_omie  |     self.run_forever()
homeassistant_omie  |   File "/usr/local/lib/python3.14/asyncio/base_events.py", line 677, in run_forever
homeassistant_omie  |     self._run_once()
homeassistant_omie  |   File "/usr/local/lib/python3.14/asyncio/base_events.py", line 2046, in _run_once
homeassistant_omie  |     handle._run()
homeassistant_omie  |   File "/usr/local/lib/python3.14/asyncio/events.py", line 94, in _run
homeassistant_omie  |     self._context.run(self._callback, *self._args)
homeassistant_omie  |   File "/config/custom_components/omie/sensor.py", line 121, in async_setup_entry
homeassistant_omie  |     await c.yesterday.async_config_entry_first_refresh()
homeassistant_omie  |   File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 326, in async_config_entry_first_refresh
homeassistant_omie  |     await self._async_config_entry_first_refresh()
homeassistant_omie  |   File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 349, in _async_config_entry_first_refresh
homeassistant_omie  |     await self._async_refresh(
homeassistant_omie  |   File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 582, in _async_refresh
homeassistant_omie  |     self.async_update_listeners()
homeassistant_omie  |   File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 203, in async_update_listeners
homeassistant_omie  |     update_callback()
homeassistant_omie  |   File "/config/custom_components/omie/sensor.py", line 85, in update
homeassistant_omie  |     local_tz = pytz.timezone(self.hass.config.time_zone)
```